### PR TITLE
Feature/mkmf

### DIFF
--- a/lib/ruby/1.8/mkmf.rb
+++ b/lib/ruby/1.8/mkmf.rb
@@ -1,36 +1,6 @@
 # ---------------------- Changed for Maglev ------------------------------------
 require 'rbconfig'
 
-# We're missing this in our rbconfig
-module Config
-  def Config::expand(val, config = Config::CONFIG)
-    (val || "").gsub!(/\$\$|\$\(([^()]+)\)|\$\{([^{}]+)\}/) do |var|
-      if !(v = $1 || $2)
-        '$'
-      elsif key = config[v = v[/\A[^:]+(?=(?::(.*?)=(.*))?\z)/]]
-        pat, sub = $1, $2
-        config[v] = false
-        Config::expand(key, config)
-        config[v] = key
-        key = key.gsub(/#{Regexp.quote(pat)}(?=\s|\z)/n) {sub} if pat
-        key
-      else
-        " "
-      end
-    end
-    val
-  end
-end
-
-# RbConfig::CONFIG and MAKEFILE_CONFIG are each not complete.
-Config::CONFIG.merge!(Config::MAKEFILE_CONFIG)
-Config::MAKEFILE_CONFIG.merge!(Config::CONFIG)
-
-# For environment overrides to work, the MAKEFILE_CONFIG hash needs to have these
-Config::MAKEFILE_CONFIG["CFLAGS"] += " $(cflags)"
-Config::MAKEFILE_CONFIG["CPPFLAGS"] += " $(DEFS) $(cppflags)"
-Config::MAKEFILE_CONFIG["CXXFLAGS"] += " $(cflags) $(cxxflags)"
-
 # This is needed later on
 CROSS_COMPILING = false
 

--- a/lib/ruby/1.8/rbconfig.rb
+++ b/lib/ruby/1.8/rbconfig.rb
@@ -108,6 +108,24 @@ module Config
   MAKEFILE_CONFIG['LDSHAREDXX']     = MAKEFILE_CONFIG['LDSHARED']
 
   MAKEFILE_CONFIG['configure_args'] = ''
+
+  def Config::expand(val, config = Config::CONFIG)
+    (val || "").gsub!(/\$\$|\$\(([^()]+)\)|\$\{([^{}]+)\}/) do |var|
+      if !(v = $1 || $2)
+        '$'
+      elsif key = config[v = v[/\A[^:]+(?=(?::(.*?)=(.*))?\z)/]]
+        pat, sub = $1, $2
+        config[v] = false
+        Config::expand(key, config)
+        config[v] = key
+        key = key.gsub(/#{Regexp.quote(pat)}(?=\s|\z)/n) {sub} if pat
+        key
+      else
+        " "
+      end
+    end
+    val
+  end
 end
 
 RbConfig = Config


### PR DESCRIPTION
Here are two more commits. One moves code from mkfm.rb to rbconfig.rb, as Peter suggested. The other changes the default INSTALL command in Makefiles, so make install works in C extension gems.
