### PR TITLE
Darwin-x86_64 fixes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -58,7 +58,7 @@ mag_name="MagLev-${1}.${PLATFORM}"
 
 # Check we're on a suitable 64-bit machine
 case "$PLATFORM" in
-    Darwin-i386)
+    'Darwin-i386'|'Darwin-x86_64')
     OSVERSION="`sw_vers -productVersion`"
     MAJOR="`echo $OSVERSION | cut -f1 -d.`"
     MINOR="`echo $OSVERSION | cut -f2 -d.`"
@@ -114,7 +114,7 @@ case "$PLATFORM" in
     # Figure out the max shared memory currently allowed
     shmall=`cat /proc/sys/kernel/shmall`
     ;;
-    Darwin-i386)
+    'Darwin-i386'|'Darwin-x86_64')
     totalMem="`sysctl hw.memsize | cut -f2 -d' '`"
     # Figure out the max shared memory segment size currently allowed
     shmmax="`sysctl kern.sysv.shmmax | cut -f2 -d' '`"

--- a/update.sh
+++ b/update.sh
@@ -61,6 +61,7 @@ fi
 
 # Detect operating system
 PLATFORM="`uname -sm | tr ' ' '-'`"
+if [ $PLATFORM = 'Darwin-x86_64' ]; then PLATFORM='Darwin-i386'; fi
 gsvers=`grep ^GEMSTONE version.txt | cut -f2 -d-`
 gss_name="GemStone-${gsvers}.${PLATFORM}"
 gss_file=${gss_name}.tar.gz


### PR DESCRIPTION
New 2011 macs (Core i5 and i7) report themselves as x86_64 not i386
