### PR TITLE
Trac #904: Use an ObjectEnumerator in enum_for, to behave more like MRI

### DIFF
--- a/src/kernel/bootstrap/Enumerator2.rb
+++ b/src/kernel/bootstrap/Enumerator2.rb
@@ -1,5 +1,14 @@
 module Enumerable
 
+  class ObjectEnumerator < Enumerator
+    # Object enumerator used for lazy enumeration
+    def next(&block)
+      # return an element of the minor-enumeration
+      @sub_enum ||= @obj.__send__(@enum_selector, *@extra_args).each
+      @sub_enum.next(&block)
+    end
+  end
+
   class ArrayEnumerator < Enumerator
     # ArrayEnumerator also used for String#each_byte
     def next

--- a/src/kernel/bootstrap/Object.rb
+++ b/src/kernel/bootstrap/Object.rb
@@ -176,9 +176,13 @@ class Object
       # catch infinite recursion from typical MRI usage pattern
       raise RuntimeError, 'Enumerator creation is subclass responsibility'
     end
-    enumerator = self.__send__(sym, *args)
+    enumerator = Enumerable::ObjectEnumerator.new(self, sym)
     ts.remove(self)
     enumerator
+  end
+
+  def to_enum(sym = :each, *args)
+    enum_for(sym, *args)
   end
 
   primitive 'freeze', 'immediateInvariant'
@@ -589,12 +593,6 @@ class Object
   def to_a
      # remove this method for MRI 1.9 compatibility
      [ self ]
-  end
-
-  def to_enum(sym = :each , *args)  # added in 1.8.7
-    # the receiver must implement the specified method that
-    #  would return an enumerator
-    self.__send__(sym, *args)
   end
 
   def to_fmt


### PR DESCRIPTION
This patch resolves the issue described in https://magtrac.gemstone.com/ticket/904, and makes the last failing Sinatra routing test pass.
