### PR TITLE
Bridge for Fixnum#between?

### DIFF
--- a/src/kernel/bootstrap/Fixnum.rb
+++ b/src/kernel/bootstrap/Fixnum.rb
@@ -62,6 +62,7 @@ class Fixnum
   primitive_nobridge '^', '_rubyBitXor:'
   primitive_nobridge '__prim_xor', '_rubyBitXor:'
   primitive_nobridge '<<', '_rubyShiftLeft:'
+  primitive_nobridge 'between?', 'between:and:'
   # >> inherited from Integer
 
   def <=>(arg)


### PR DESCRIPTION
1.8.7 has added support for Fixnum#between?. This can be bridged to Smalltalks Magnitude>>between:and:
