### PR TITLE
Workaround to have Rails 3 working out of the box

### DIFF
--- a/src/kernel/post_prims.rb
+++ b/src/kernel/post_prims.rb
@@ -9,3 +9,5 @@ require 'kernel/post_prims/Object.rb'
 require 'kernel/post_prims/StructTms.rb'
 require 'kernel/post_prims/bigdecimal.rb'  
 require 'kernel/post_prims/ffi.rb'  
+
+require 'kernel/workarounds/load_all.rb'

--- a/src/kernel/workarounds/load_all.rb
+++ b/src/kernel/workarounds/load_all.rb
@@ -1,0 +1,7 @@
+# Meta-file, to load all current workarounds in this directory.
+
+Dir[File.expand_path("../*.rb", __FILE__)].each do |f|
+  warn "Loading workaround #{File.basename(f)}"
+  require f
+end
+

--- a/src/kernel/workarounds/tzinfo.rb
+++ b/src/kernel/workarounds/tzinfo.rb
@@ -1,0 +1,14 @@
+# This works around issue #39
+#
+# We evaluate rescue clauses too early. In Rails,
+# specifically activesupport/lib/active_support/values/time_zone.rb,
+# there is a rescue clause referencing TZInfo::InvalidTimezoneIdentifier
+# where tzinfo is only lazily loaded after the begin-statement.
+# By commiting am empty class to the stone, we work around our
+# undefined constant error in that case.
+
+module TZInfo
+  class InvalidTimezoneIdentifier < StandardError
+  end
+end
+


### PR DESCRIPTION
Until issue #36 we cannot run rails without patching the lazy tzinfo loading in ActiveSupport. If we, however, decide to install this workaround as part of the bootstrap, nobody will have to patch Rails.
