### PR TITLE
SocketError_NotConnected instead of Errno::ECONNREFUSED

### DIFF
--- a/src/smalltalk/ruby/RubySocket.gs
+++ b/src/smalltalk/ruby/RubySocket.gs
@@ -102,6 +102,11 @@ signalSocketError: errText
     errSym ifNil:[
       ^ SocketError signal: 'SocketError_unknown ' , errText
     ].
+    errSym = #NotConnected "Fix github #97"
+      ifTrue: [| errno |
+        errno := (Exception errnoTables at: AbstractException cpuOsKind)
+                   indexOf: 'ECONNREFUSED'.
+        ^ (SystemCallError @ruby1:new: errText value: errno) signal].
     ^ SocketError signal: 'SocketError_' , errSym , ' ' , errText
   ].
   ^ exCls signal: exCls name , ' ' , errText
@@ -120,6 +125,11 @@ signalSocketError: errText
     errSym ifNil:[
       ^ SocketError signal: 'SocketError_unknown ' , errText
     ].
+    errSym = #NotConnected "Fix github #97"
+      ifTrue: [| errno |
+        errno := (Exception errnoTables at: AbstractException cpuOsKind)
+                   indexOf: 'ECONNREFUSED'.
+        ^ (SystemCallError @ruby1:new: errText value: errno) signal ].
     ^ SocketError signal: 'SocketError_' , errSym , ' ' , errText
   ].
   ^ exCls signal: exCls name , ' ' , errText


### PR DESCRIPTION
Writing to a TCPSocket that isn't connected should throw Errno::ECONNREFUSED instead of a SocketError. This breaks the new integration test in Sinatra (the rescue clause doesn't work, see http://ci.rkh.im/job/Sinatra%20%28master%29/rack=rack-1.3.0,ruby=maglev-head,tilt=tilt-1.3/lastCompletedBuild/testReport/)
