### PR TITLE
define rb_cstr_to_dbl (needed for json gem)

### DIFF
--- a/lib/ruby/1.8/include/ruby.h
+++ b/lib/ruby/1.8/include/ruby.h
@@ -850,6 +850,8 @@ RUBY_DLLSPEC VALUE rb_str2inum(VALUE str, int base);
 
 RUBY_DLLSPEC VALUE rb_cstr2inum(const char* str, int base) ;
 
+#define rb_cstr_to_dbl(x, badcheck) rb_num2dbl(rb_cstr2inum(x, 10))
+
 //  define rb_cstr_to_inum(VALUE str, int base, badcheck) rb_cstr2inum(str, base)
 
 


### PR DESCRIPTION
Just a trivial change in the ruby.h, could you pull that change into SVN? We need to use the 1.6.3 version of the JSON gem (which I just pushed to our Maglev Rubygems account)
