### PR TITLE
Implemented IO.dup.

### DIFF
--- a/src/kernel/bootstrap/File.rb
+++ b/src/kernel/bootstrap/File.rb
@@ -1137,6 +1137,18 @@ class File
 
   alias :syswrite :write
 
+  def dup
+    raise IOError, "closed stream" if self.closed?
+
+    if @_st_fileDescriptor >= 0 && @_st_fileDescriptor <= 2
+      self
+    else
+      file = self.class.new(@_st_pathName, @_st_mode)
+      file.seek(self.tell)
+      file
+    end
+  end
+
 end
 File.__freeze_constants
 


### PR DESCRIPTION
Works for `File` and `std*` only so far. `std*.dup` returns `self`. Dupping files should use syscall `dup` to allow dupping already deleted files (changes to GemStone necessary). However, in most cases this should suffice.
