### PR TITLE
Infinite recursion in Array subclasses caused by method overloading & super

### DIFF
--- a/src/kernel/bootstrap/Array.rb
+++ b/src/kernel/bootstrap/Array.rb
@@ -1553,7 +1553,7 @@ class Array
 
   def shift(count=MaglevUndefined)  # added in 1.8.7
     if count._equal?(MaglevUndefined) 
-      return self.shift()
+      return self.__shift
     end
     cnt = Type.coerce_to(count, Fixnum, :to_int)
     if cnt < 0
@@ -1574,16 +1574,10 @@ class Array
   end
 
   def shift
-    sz = self.__size
-    elem = nil
-    unless sz._equal?(0)
-      elem = self.__at(0)
-      self.__remove_from_to_(1, 1)  # one-based args
-    end
-    elem
+    self.__shift
   end
 
-  def __shift  # used by Argf implementation
+  def __shift
     sz = self.__size
     elem = nil
     unless sz._equal?(0)

--- a/src/test/github250.rb
+++ b/src/test/github250.rb
@@ -1,0 +1,11 @@
+class Sexp < Array
+  def shift
+    raise if self.empty?
+    super
+  end
+end
+
+s = Sexp.new
+s << 42
+raises "Shift broken" unless s.shift == 42
+# Passes if it doesn't cause infinite recursion

--- a/src/test/vmunit.conf
+++ b/src/test/vmunit.conf
@@ -450,6 +450,7 @@ github211.rb
 github222.rb
 github224.rb
 github243.rb
+github250.rb
 
 testMarshal.rb   # after other coverage of Hash
 #


### PR DESCRIPTION
I have no idea how to fix this one other than to get rid of the overloading entirely. There's not much point to it, is there?

``` ruby
class Sexp < Array
  def shift
    raise if self.empty?
    super
  end
end

s = Sexp.new
s << 42
p s.shift
```
