### PR TITLE
added URI::Parser in lib/ruby/1.9/uri/common.rb.

### DIFF
--- a/lib/ruby/1.9/uri/common.rb
+++ b/lib/ruby/1.9/uri/common.rb
@@ -601,6 +601,17 @@ module URI
       /(?=#{Regexp.union(*schemes)}:)#{PATTERN::X_ABS_URI}/xn
     end
   end
+  
+  class Parser
+  #Dummy Class that does not provide any useful functionality.
+  #This is a patch for the fact that encoding is not yet implemented.
+    def escape(str)
+      str
+    end
+    def unescape(str)
+      str
+    end
+  end
 
 end
 


### PR DESCRIPTION
The parser class does not provide much useful functionality except for its presence.
