### PR TITLE
Fixed $stdin = StringIO.new and Kernel#puts not using $stdin.

### DIFF
--- a/src/kernel/bootstrap/File2.rb
+++ b/src/kernel/bootstrap/File2.rb
@@ -3,9 +3,10 @@
 class File
   def self.__validate_stdin_value(file)
     # used in generated code value for     $stdin = file
-    cls = file.class
-    if cls == File 
-      return file
+    unless file._equal?(nil)
+      if file.respond_to?(:rewind)
+        return file
+      end
     end
     raise TypeError, 'expected a File'
   end

--- a/src/kernel/bootstrap/Kernel.rb
+++ b/src/kernel/bootstrap/Kernel.rb
@@ -469,8 +469,7 @@ module Kernel
   primitive 'format*', 'sprintf:with:'
 
   def gets(sep=$/)
-    # TODO: Need to use-up ARGV first...
-    STDIN.gets(sep)
+    $stdin.gets(sep)
   end
 
   primitive 'global_variables', 'rubyGlobalVariables'


### PR DESCRIPTION
Fixes #298.

Fixed __validate_stdin_value to use ducktyping to allow assignment of StringIO
Fixed Kernel#gets to use $stdin, not STDIN.

STDIN should only be used to hold onto the original. Nothing more.
