### PR TITLE
made the rubyspecs for Dir.entries run

### DIFF
--- a/spec/tags/core/dir/entries_tags.txt
+++ b/spec/tags/core/dir/entries_tags.txt
@@ -1,2 +1,0 @@
-fails:Dir.entries calls #to_path on non-String arguments
-fails:Dir.entries accepts an options Hash

--- a/src/kernel/bootstrap/Dir.rb
+++ b/src/kernel/bootstrap/Dir.rb
@@ -47,7 +47,8 @@ class Dir
     Errno.handle(__rmdir(dirname), "delete #{dirname}")
   end
 
-  def self.entries(dirname)
+  def self.entries(dirname, opts = {})
+    dirname = dirname.to_path unless dirname.is_a? String
     Dir.new(dirname).entries
   end
 


### PR DESCRIPTION
a hash option was required by 

> require "tempdir"

added that option and made the rubyspec run.
