### PR TITLE
Added method to Module to raise expected TypeError instead of NameError

### DIFF
--- a/src/smalltalk/ruby/Module_ruby.gs
+++ b/src/smalltalk/ruby/Module_ruby.gs
@@ -436,6 +436,12 @@ ZeroDivide .     1  "mapped to Ruby by Ruby bootstrap"
 category: 'Ruby support'
 
 method:
+newRubySubclass: aString  instancesPersistent: ipersistBool fixedIvs: ivList
+  "this is sometimes called when a class X < ModuleX inherits from a module"
+  ArgumentTypeError signal: 'wrong argument type ', self class name
+%
+
+method:
 transientMethodDictForEnv: envId put: aValue
   "aValue should be a GsMethodDictionary, or nil ,
    caller responsible for _refreshClassCache.


### PR DESCRIPTION
This was the error before the change:

```
NoMethodError: a MessageNotUnderstood occurred (error 2010), a Module does not understand  #'newRubySubclass:instancesPersistent:fixedIvs:'
```

This is the error after the change: 

```
TypeError: wrong argument type Module
```

This is the code that belongs to it:

```
class ProjectModel < MaglevRecord::RootedBase
end
```

See the commit message for more information.
