### PR TITLE
Object>>_nameForMethodMissing

### DIFF
--- a/src/packages/Maglev.package/Object.extension/instance/_nameForMethodMissing.st
+++ b/src/packages/Maglev.package/Object.extension/instance/_nameForMethodMissing.st
@@ -1,6 +1,9 @@
 *maglev-runtime
 _nameForMethodMissing
-"A ruby primitive , part of fix for Trac 752"
-
- ^ self virtualClass rubyFullName: 1"__callerEnvId"
+  | myName |
+  "A ruby primitive , part of fix for Trac 752"
+  myName := self virtualClass rubyFullName: 1"__callerEnvId".
+  (myName == nil) 
+    ifTrue: [^ 'Unknown']
+    ifFalse: [^ myName]
 


### PR DESCRIPTION
method Object>>_nameForMethodMissing returns now 'Unknown', if name was nil. produces readable error messages, if method missing. 

old behavior raised "nil does not undestand <some string method>" when I running rails.
