### PR TITLE
when inheriting from nonclass an error is thrown

### DIFF
--- a/src/smalltalk/ruby/Object_ruby.gs
+++ b/src/smalltalk/ruby/Object_ruby.gs
@@ -248,6 +248,11 @@ _rubyNilQ
 !  _rubyKind_Block_String_Range_Regexp_Array deleted
 !  _rubyTo: , _rubyTo_:    implemented in .mcz
 
+method:
+newRubySubclass: aString  instancesPersistent: ipersistBool fixedIvs: ivList
+  "this is sometimes called when a class X < ModuleX inherits from a module"
+  ArgumentTypeError signal: 'wrong argument type ', self class rubyFullName, '. expected a class.'
+%
 
 category: 'Ruby private'
 method:


### PR DESCRIPTION
```
class X < 1 # some object that is not a class
end
```

now creates the 

```
TypeError: wrong argument type Fixnum. expected a class.
```

instead of the former 

```
NoMethodError: a MessageNotUnderstood occurred (error 2010), a SmallInteger does not understand  #'newRubySubclass:instancesPersistent:fixedIvs:'
```

The specs do not test this case in spec/rubyspec/core/class/new_spec.rb. They test Class.new which raises a TypeError. 

```
lambda { Class.new("")         }.should raise_error(TypeError)
lambda { Class.new(1)          }.should raise_error(TypeError)
lambda { Class.new(:symbol)    }.should raise_error(TypeError)
lambda { Class.new(mock('o'))  }.should raise_error(TypeError)
lambda { Class.new(Module.new) }.should raise_error(TypeError)
```

I did not find other specs that test my code directly.
