### PR TITLE
Update download host to seaside.gemtalksystems.com

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -107,9 +107,6 @@ cd $MAGLEV_HOME
 mkdir -p locks
 # and the correct updated keyfile
 rm -f etc/maglev.demo.key
-
-echo "[Info] Copying key"
-
 ln -sf maglev.demo.key-$PLATFORM etc/maglev.demo.key
 # Make sure we have specs and benchmarks.
 echo "[Info] updating MSpec and RubySpec submodules"
@@ -144,7 +141,7 @@ if [  -e "`which rake 2>/dev/null`" ]; then
         echo "[Info] In-place upgrade not possible. Removing existing 'maglev' configuration file."
         rake stone:destroy[maglev] >/dev/null
     fi
-echo 'foo'
+
     rake build:clobber
     extent0='gemstone/bin/extent0.dbf'
     echo "[Info] Building new extent0.ruby.dbf from $extent0 and creating default maglev stone"


### PR DESCRIPTION
I just tried installing MagLev on a new laptop and it failed due to a download redirect. This fixes that.
