### PR TITLE
Expose Time#nsec

### DIFF
--- a/spec/tags/core/time/nsec_tags.txt
+++ b/spec/tags/core/time/nsec_tags.txt
@@ -1,4 +1,3 @@
-fails:Time#nsec returns 0 for a Time constructed with a whole number of seconds
 fails:Time#nsec returns the nanoseconds part of a Time constructed with a Float number of seconds
 fails:Time#nsec returns the nanoseconds part of a Time constructed with an Integer number of microseconds
 fails:Time#nsec returns the nanoseconds part of a Time constructed with an Float number of microseconds

--- a/src/kernel/bootstrap/Time.rb
+++ b/src/kernel/bootstrap/Time.rb
@@ -332,6 +332,7 @@ class Time
   def usec
     @_st_microseconds % 1_000_000 
   end
+  alias_method :nsec, :usec
 
   def to_i
     @_st_microseconds.__divide(1_000_000)


### PR DESCRIPTION
Turns out it was already there as Time#usec.
For copiousfreetime/hitimes#16
