### PR TITLE
Use portable shebang line for bash

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 #=========================================================================
 # Copyright (C) GemStone Systems, Inc. 2010.


### PR DESCRIPTION
Switched the shebang to `/usr/bin/env bash` to be more portable, since FreeBSD and others don't have a `/usr/bash`.
