### PR TITLE
Updates OpenSSL download url

### DIFF
--- a/lib/ruby/1.9/openssl/ext/extconf.rb
+++ b/lib/ruby/1.9/openssl/ext/extconf.rb
@@ -59,7 +59,7 @@ module GetOpenSSLHeaders
           raise "Must have curl or wget"
         end
       end
-      system "tar xzf #{file}"
+      system "tar xzf #{file} && mv openssl-#{version}j openssl-#{version}"
     end
   end
 


### PR DESCRIPTION
The OpenSSL download URL changed 10/15/14, 2:24:00 PM

This adjusts the download URL and closes #361
