### PR TITLE
Allen magparse3

### DIFF
--- a/src/kernel/bootstrap/Globals.rb
+++ b/src/kernel/bootstrap/Globals.rb
@@ -158,12 +158,12 @@ RUBY_ENGINE = 'maglev'
 # RUBY_PLATFORM  is installed in RubyContext>>_initTransient:
 RUBY_VERSION = '1.9.3'
 # Note - the packager modifies the date on any line starting with RUBY_RELEASE_DATE
-RUBY_RELEASE_DATE = '2015-07-07'
+RUBY_RELEASE_DATE = '2015-07-20'
 RUBY_PATCHLEVEL = 327
 RUBY_DESCRIPTION = 'ruby 1.9.3 (maglev patchlevel 327)'
 RUBY_COPYRIGHT = 'ruby - Copyright (C) 1993-2010 Yukihiro Matsumoto; maglev additions Copyright(C) 2009-2010 GemStone Systems Inc.'
 
-VERSION = '1.2Alpha6'
+VERSION = '1.2Alpha7'
 
 MAGLEV_VERSION = VERSION  # per Trac 901
 

--- a/src/kernel/parser/Makefile
+++ b/src/kernel/parser/Makefile
@@ -7,7 +7,7 @@ ifeq "$(GEMSTONE)" ""
 else
   ICU_INCL := -I$(GEMSTONE)/../../icu/source/common
 endif
-GSVERSION   := 3.1.0.2.2-64
+GSVERSION   := 3.1.0.2.3-64
 
 CC        := /usr/bin/g++
 COPTIMIZE_FLAGS := -O3 -g -Wuninitialized

--- a/src/kernel/parser/rubyom.hf
+++ b/src/kernel/parser/rubyom.hf
@@ -16,7 +16,7 @@
 #include "opalcls.ht"
 #include "gcistring.hf"
 
-typedef OopType OopNumberType ;
+typedef OopType OopNumberType ;  
 typedef unsigned char    BoolByteType;
 
 #define TWO_TO_40   1099511627776L
@@ -35,7 +35,12 @@ enum { OOP_NUM_SHIFT = 8 };
 #define OOP_TO_CHAR_(anOop) (((OopType)(anOop) >> GCI_OOP_SPECIAL_VALUE_SHIFT) & CHAR32_MAX_VALUE)
 
 /* OOP_NUM_TAG_BITS from gcioop.ht */
+
 #define OOP_TO_I64(anOop) ((int64)(anOop) >> OOP_NUM_TAG_BITS )
+  // caller must check that anOop is a SmallInteger
+
+
+// Assertion support
 
 int HostCallDebuggerMsg_fl(const char* msg, const char* filename, int line);
 
@@ -54,17 +59,20 @@ int HostCallDebuggerMsg_fl(const char* msg, const char* filename, int line);
 #define UTL_IF_DEBUG( x ) { }
 #define UTL_DEBUG_DEF( x ) /*  */
 #endif
+// end Assertion support
 
 #define UTL_ARRAY_LENGTH(a) ( sizeof((a)) / sizeof((a)[0]) )
 
 static inline OopNumberType OOP_TO_BIT(OopType anOop)
 {
+  // converts an OopType of a persistent object to an OopNumberType
   UTL_ASSERT( OOP_IS_POM(anOop));
   return anOop >> OOP_NUM_SHIFT ;
 }
 
 static inline OopType BIT_TO_OOP(OopNumberType aBitNum)
 {
+  // converts an OopNumberType to the OopType of a persistent object
   return (aBitNum << OOP_NUM_SHIFT) | OOP_TAG_POM_OOP;
 }
 
@@ -76,6 +84,8 @@ enum {
 
 static inline OopType OOP_makeSelectorId(uint64 environId , OopType selObjId)
 {
+  // given the environId and  selObjId which is the object id of a Symbol ,
+  // return the selectorId which is a SmallInteger 
   UTL_ASSERT(OOP_IS_POM(selObjId));
   UTL_ASSERT(environId < COMPILE_ENV_MAX );
   UTL_ASSERT((selObjId >> OOP_NUM_SHIFT) <= OOP_NUM_MAX);
@@ -88,6 +98,19 @@ static inline OopType OOP_makeSelectorId(uint64 environId , OopType selObjId)
 
 class omObjSType
 {
+ // a C variable of type  omObjSType*  is a pointer to an in-memory object,
+ // where in-memory means the object was created in, or faulted into
+ // the VM's temporary object memory.  For some function calls and returns
+ // the args or result may also be the object id of a special object
+ // such as OOP_NIL or a SmallInteger .
+
+ // When an argument of type omObjSType* is passed to an om:: function 
+ // and the function is documented as "possible gc" or "may cause gc",
+ // then that pointer is not valid after the function returns.
+ // To access the object again you would need to have saved it
+ // in a handle, obtained from OmScopeType::add or 
+ // OmScopeType::newHandle , and then dereference the handle after
+ // the function call which invalidated the pointer.
  public:
   inline OopType classId();
 };
@@ -96,11 +119,15 @@ class om;
 
 static inline omObjSType* OOP_OF_SMALL_LONG_(int64 arg)
 {
+  // convert a C int64 value to the objectId of a SmallInteger ,
+  // with result casted to an object pointer.
   UTL_ASSERT(GCI_I64_IS_SMALL_INT(arg));
   return (omObjSType*)((arg << 3) | OOP_TAG_SMALLINT) ;
 }
 
 enum {
+  // contants used in Smalltalk primitives to access the arguments 
+  // relative to the smalltalk stack pointer.
   FP_codePtr_OFS = -1, // always a Ram oop of a GsNativeCode or GsNMethod
   FP_savedFP_OFS =    0,
   FP_rtnAddr_OFS =    1,  // Solaris native code , stores rtnAddr - 8
@@ -110,35 +137,43 @@ enum {
   FP_primEntrySP_to_argLimit_OFS = FP_rtnAddr_OFS - FP_codePtr_OFS  // &SP[lastArg] - 1
 };
 
+// macros used in Smalltalk primitives to access the arguments.
+//  ARStackPtr is always an argument to the primitive.
 #define DOPRIM_STACK(__n) (*(ARStackPtr + (__n) + FP_primEntrySP_to_argLimit_OFS))
 
 #define DOPRIM_STACK_ADDR(__n) (ARStackPtr + (__n) + FP_primEntrySP_to_argLimit_OFS)
 
+
 #if defined(FLG_DEBUG)
 // reenable if doing lots of new primitives in the parser; needs a slow build
 // void DoPrimCheckNumArgs(om *omPtr, omObjSType **SP, int expectedNumArg);
-// #define DOPRIM_ARGS(__omptr, __n) DoPrimCheckNumArgs(__omptr, ARStackPtr, __n)
+// define DOPRIM_ARGS(__omptr, __n) DoPrimCheckNumArgs(__omptr, ARStackPtr, __n)
 #define DOPRIM_ARGS(__omptr, __n) { }
 #else
 #define DOPRIM_ARGS(__omptr, __n) { }
 #endif
 
+// ramOop casts an argument to  omObjSType*
 #define ramOop(anOop) ((omObjSType*)((uintptr_t)anOop))
+
+// Smalltalk nil, true, false , zero   casted to an omObjSType*
 #define ram_OOP_NIL   ramOop(OOP_NIL)
 #define ram_OOP_FALSE ramOop(OOP_FALSE)
 #define ram_OOP_TRUE  ramOop(OOP_TRUE)
 #define ram_OOP_Zero  ramOop(OOP_Zero)
 
-class ComStateType;
+class ComStateType;  // internal state of the Smalltalk parser/code generator
 
 class H_CByteArray
 {
+  // accessor for an instance of CByteArray 
  public:
    static inline int64 sizeBytes(int64 info) { return info >> 4; }
 };
 
 class OmScopeType
 {
+  // garbage collection scope on the C stack , known to the garbage collector
   intptr_t a;  
   intptr_t b;
   intptr_t c; 
@@ -146,14 +181,18 @@ class OmScopeType
 
  public:
   OmScopeType(om *omPtr) {
-    initialize_(omPtr);
+    initialize_(omPtr);  // registers this instance with the garbage collector
   }
   ~ OmScopeType() {   
-    deinitialize_();
+    deinitialize_();  // removes this instance from the garbage collector
   } 
   void initialize_(om *omPtr);
   void deinitialize_(); 
-  omObjSType** add_(omObjSType *obj);
+
+  // The variants of add and newHandle may only be called on the most recently
+  // registered instance.  Instances further up the C stack 
+  //  may not be added to (a Smalltalk Error will be signalled).
+  omObjSType** add_(omObjSType *obj); 
   inline omObjSType** newHandle() { return add_(ram_OOP_NIL); }
   inline omObjSType** add(omObjSType *obj) { return add_(obj); }
 };
@@ -163,14 +202,14 @@ enum { GEN_MAX_RubyFixedArgs = 74    // 'z' - '0'
      };
 
 class YyStackElement {  // for Maglev parser
-   // must agree with VM's om.hf, used by omgc.c  
+   // must agree with VM's om.hf, traversed by VM garbage collector
  public:
   omObjSType *obj;
   short state;
 };
 
 class YyStackData {
-   // must agree with VM's om.hf, used by omgc.c  
+   // must agree with VM's om.hf, traversed by VM garbage collector
  public:
   YyStackElement *mark;
   YyStackElement *base;
@@ -193,10 +232,17 @@ class rb_parse_state;
 
 class om
 {
+  // See comments in class omObjSType about validity of object pointers
+  // after function calls.
+
+  // all "offset" arguments to Fetch or Store calls are ZERO BASED .
+  // as if the instVars were a C array    omObjSType* instVars[N];
+
  public:
   static OopType objIdOfObj__(om *omPtr, omObjSType* obj);
 
   static omObjSType* FetchOop(omObjSType* obj, int64 offset); // may cause gc
+
   static int64 FetchSize_(omObjSType* obj);
 
   static void StoreOopR(om *omPtr, omObjSType** objH, int64 offset, omObjSType **valueH); // may cause gc
@@ -262,6 +308,7 @@ class om
   }
 
   static void corruptObj(omObjSType *obj, const char* reason);
+    // signals a Smalltalk Error , number 2261
 
   static inline void StoreSmallInt_(om *omPtr, omObjSType** obj, int64 offset, int64 value) {
     // may cause gc
@@ -284,22 +331,31 @@ class om
   }
 
 
+  // the IntRecur functions do a Smalltalk message send and return the
+  // result .
   static omObjSType* IntRecurFromPrim_(om *omPtr, omObjSType**  recH, OopType selectorId);
   static omObjSType* IntRecurFromPrim__(om *omPtr, omObjSType**  recH, OopType selectorId,
 		int64 numArgs, omObjSType ***handlesArray);
 
-  omObjSType** NewGlobalHandle();
+  omObjSType** NewGlobalHandle(); 
+    // allocates a handle that is valid for the life of the VM's session
 
   static uintptr_t FetchCData(omObjSType* obj); // no gc
+    // returns the CData pointer for the object, or NULL if no CData.
+    // used in the parser to access the C memory body of an instance of CByteArray
  
+  // accessor and setters for compiler state .
+  // the setters make the garbage collector aware of the ruby parser state.
   rb_parse_state* rubyParseState();
   void set_rubyParseState( rb_parse_state *ps);
   void set_rubyParseStack( YyStackData *stk);
   ComStateType* compilerState();
+  
 };
 
 inline OopType omObjSType::classId()
 {
+  // return the object id of this object's class .
   UTL_ASSERT(OOP_IS_RAM_OOP(this));
   return om::FetchClassId_(this);
 }
@@ -308,32 +364,65 @@ void GemSupErr_oo_(int errorNumber, omObjSType* arg1, omObjSType* arg2);
 
 void GemErrAnsi(om *omPtr, int errorNumber, const char* reason, const char* detail);
 
+// Functions to create a new instances of Symbol 
+// instances of Symbol are always canonicalized by the VM which
+// does lookups in the persistent, conflict-free AllSymbols collection and 
+// communicates through the stoned process to the symbolgem process as needed.
+//
 omObjSType*  ObjNewSym(om *omPtr, const char *string);
+  // returns a Symbol with value  string .
+
 omObjSType* ObjExistingCanonicalSym__(om *omPtr, omObjSType **argH);
+// returns NULL if the String *argH does not have the value of an existing
+// Symbol
+
 omObjSType* ObjCanonicalSymFromCStr(om *omPtr, const ByteType *buf,
                 int64 keyLen, OopType rubyPrefixSymbolId/*maybe OOP_NIL*/ );
+// returns a Symbol with with specified value.
 
 char *ComHeapMalloc(ComStateType *cst, unsigned int itsSize );
+  // Allocate memory from the VM's compiler heap area  .
   // returned memory is automatically freed at end of a method compilation
+  // without having to make individual free calls.
 
 void ComHeapInit(ComStateType *cst);
+  // initialize or reinitialize the compiler heap to empty.
 
+
+// various numeric conversion functions operating between C data
+// and Smalltalk numeric classes.
+//
 BoolType FloatPrimFetchArg(om *omPtr, omObjSType** objH, double *aDouble);
+ // returns 1 if *objH is an instance of Float or SmallDouble,
+ //  and returns the value of that object in *aDouble  ,
+ // otherwise returns 0 and *aDouble is undefined.
 
 omObjSType*  FloatPrimDoubleToOop(om *omPtr, double x);
+  // returns an instance of  Float or SmallDouble with value x
 
-omObjSType*  LrgNegate_(om *omPtr, omObjSType** obj );
+omObjSType*  LrgNegate_(om *omPtr, omObjSType** objH );
+  // if *objH is a LargeInteger or SmallInteger, return the negated value
+  // otherwise signal an error .
+
 omObjSType* LrgRubyStringToInteger(om *omPtr,
         omObjSType** stringH, int64 radix, int charSize);
-omObjSType* LrgInt64ToOop(om *omPtr, int64 anInt);
+  // if *stringH is a String parse it as an Integer with specified radix.
+  // return NULL if *stringH is not a String or has invalid format.
 
+omObjSType* LrgInt64ToOop(om *omPtr, int64 anInt);
+  // return a SmallInteger or LargeInteger with value anInt
+
+// The two primitives in the maglev parser called from smalltalk.
 omObjSType *MagCompileError902(om *omPtr, omObjSType **ARStackPtr);
 omObjSType *MagParse903(om *omPtr, omObjSType **ARStackPtr);
 
 omObjSType* GemDoSessionSymList( om *omPtr );
+  // returns the SymbolList of the current session's UserProfile.
 
 omObjSType*  GemSupSearchSymList(om *omPtr,
                 omObjSType** symbolList, omObjSType** Symbol );
+  // lookup the specified Smalltalk symbol in the specified SymbolList,
+  // returns NULL if not found.
 
 
 #endif

--- a/version.txt
+++ b/version.txt
@@ -1,3 +1,3 @@
-maglev 1.2Alpha6 (ruby 1.9) (2015-07-07 rev 1.2Alpha5-36816)
-GEMSTONE: gss64_maglev_1_9_branch-36816
-Tue Jul 7, 14:02:41 PDT 2015
+maglev 1.2Alpha7 (ruby 1.9) (2015-07-20 rev 1.2Alpha7-36916)
+GEMSTONE: gss64_maglev_1_9_branch-36916
+Mon Jul 20, 15:00:00 PDT 2015


### PR DESCRIPTION
We have published these builds, server build 36916  version 3.1.0.2.3
http://seaside.gemtalksystems.com/maglev/GemStone-36916.Darwin-i386.tar.gz
http://seaside.gemtalksystems.com/maglev/GemStone-36916.Linux-x86_64.tar.gz
And I think I have edited the  files  Globals.rb,  parser/Makefile, and version.txt for the
changes in version numbers.    The Linux server is unchanged except for version number.
The Darwin server should now have   _rb_cArray  and similar  global variables exported
from the libgcilnk*.dylib   for use by Ruby C extensions.