### PR TITLE
Adding Rubygems to IRB

### DIFF
--- a/bin/maglev-irb
+++ b/bin/maglev-irb
@@ -24,7 +24,7 @@ end
 #     end
 
 require "irb"
-
+require "rubygems"
 
 if __FILE__ == $0
   IRB.start(__FILE__)


### PR DESCRIPTION
Running the IRB is painful without it. Ideally rubygems would be included in the bootstrap. This is just a stopgap measure.