### PR TITLE
Updates version of icu4c

### DIFF
--- a/lib/ruby/1.9/openssl/ext/extconf.rb
+++ b/lib/ruby/1.9/openssl/ext/extconf.rb
@@ -47,7 +47,7 @@ module GetOpenSSLHeaders
 
   def get_headers(version)
     unless File.directory?("openssl-#{version}")
-      letter = 's'
+      letter = 't'
       file = "openssl-#{version}#{letter}.tar.gz"
       openssl_url = "ftp://ftp.openssl.org/source/#{file}"
       message " Downloading #{openssl_url}\n"

--- a/src/kernel/parser/Makefile
+++ b/src/kernel/parser/Makefile
@@ -22,7 +22,7 @@ else ifeq "$(OS)" "Darwin"
   EXT       := dylib
   OSLDFLAGS := -Wl,-flat_namespace -Wl,-undefined -Wl,warning -Wl,-exported_symbols_list -Wl,magparse.osx.exp
   OSCCWARN  := 
-  OSCCINC   := -I/usr/local/Cellar/icu4c/54.1/include
+  OSCCINC   := -I/usr/local/Cellar/icu4c/57.1/include
 else
   $(error UNKNOWN OS: $(OS))
 endif


### PR DESCRIPTION
Hello.

icu4c-54.1 has some vulnerabilities.
http://www.kb.cert.org/vuls/id/602540  
According to this article, we have to update icu4c 55.1 or above. I changed it to 57.1 so the latest version is 57.1 now.