### PR TITLE
Fixes sinatra example

### DIFF
--- a/examples/sinatra/simple_blog/config.ru
+++ b/examples/sinatra/simple_blog/config.ru
@@ -6,7 +6,7 @@
 require 'sinatra'
 require 'blog_app'
 require '../object_inspector/objectlog_app'
-require 'txn_wrapper'
+require 'lib/commit_code'
 
 use MagLevTransactionWrapper
 


### PR DESCRIPTION
Hello! I fixed require path in sinatra example.

On prev codes, this error message appeared in my environment.
```
$ maglev-bundle exec rackup
ERROR 2702 , a RubyLoadError occurred (error 2702), no such file to load -- txn_wrapper (LoadError)
topaz 1> exit
```

After I fixed, sinatra app runs fine.